### PR TITLE
fixed background sizing

### DIFF
--- a/arbitrator/static/arbitrator/css/background.css
+++ b/arbitrator/static/arbitrator/css/background.css
@@ -7,8 +7,7 @@ html, body {
 body {
   box-sizing: border-box;
   background-image: url("./../images/indexBackground.jpg");
-  background-size: auto;
+  background-size: auto 100vmax;
   background-repeat: no-repeat;
-  box-sizing: border-box;
 }
 


### PR DESCRIPTION
fixed background sizing that in the previous version when the window is bigger than the resolution of the background image, the image wont scale up as  a result it gave white space. 
In this fixed version the image can scale to the window width.